### PR TITLE
Update some versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.2.0
+- Updated RxSwift to version 6.5
+
 # 6.1.0
 - Added support for iOS 15/Xcode 13.
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "5.1.1"
+github "ReactiveX/RxSwift" "6.6.0"

--- a/README.md
+++ b/README.md
@@ -72,19 +72,21 @@ Want to migrate from 4.x to 5.x? Check guidelines [here](https://github.com/Poli
 [CocoaPods](http://cocoapods.org) is a dependency manager for CocoaProjects.
 To integrate RxBluetoothKit into your Xcode project using CocoaPods specify it in your `Podfile`:
 ```ruby
-pod 'RxBluetoothKit'
+pod 'RxBluetoothKit_Airthings'
 ```
 Then, run the following command:
 `$ pod install`
 
 ## Carthage
 
-[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.
-To integrate RxBluetoothKit into your Xcode project using Carthage  specify it in your `Cartfile`:
+#### FYI: Carthage has some issues with Xcode 12 or later. Therefore it is not supported properly. Always welcome developers to fix it.
+
+~[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.
+To integrate RxBluetoothKit into your Xcode project using Carthage  specify it in your `Cartfile`:~
 ```swift
-github "Polidea/RxBluetoothKit"
+~github "Polidea/RxBluetoothKit"~
 ```
-Then, run `carthage update` to build framework and drag `RxBluetoothKit.framework` into your Xcode project.
+~Then, run `carthage update` to build framework and drag `RxBluetoothKit.framework` into your Xcode project.~
 
 ## Swift Package Manager
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then, run the following command:
 ~[Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.
 To integrate RxBluetoothKit into your Xcode project using Carthage  specify it in your `Cartfile`:~
 ```swift
-~github "Polidea/RxBluetoothKit"~
+github "Polidea/RxBluetoothKit"
 ```
 ~Then, run `carthage update` to build framework and drag `RxBluetoothKit.framework` into your Xcode project.~
 

--- a/RxBluetoothKit_Airthings.podspec
+++ b/RxBluetoothKit_Airthings.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxBluetoothKit_Airthings"
-  s.version          = "6.1.0"
+  s.version          = "6.2.0"
   s.summary          = "Bluetooth library for RxSwift"
 
   s.description      = <<-DESC


### PR DESCRIPTION
Steps to do:


- [x] add new change log to Changelog.md
- [x] change RxBluetoothKit.podspec with new library version
- [x] generate new doc by running script ./scripts/generate-docs.sh x.x.x (No need)
- [ ] ~create archive by running carthage build --no-skip-current && carthage archive RxBluetoothKit (I'm stuck here)~ Ignore this as we don't use it in our project and latest Xcode versions (after 12) give a lot of hassle to maintain.  
- [x] create new Pull Request with that changes and merge it
- [ ] create new release on github and add archive previously created
- [ ] add library to cocoapods trunk by running: pod trunk push RxBluetoothKit.podspec

Error I'm seeing:

```
    Run reason: rule has never built
error: /Users/eirik/Documents/Jobb/Airthings/Kode/RxBluetoothKit/Carthage/Build/iOS/RxSwift.framework: No such file or directory (in target 'RxBluetoothKit iOS' from project 'RxBluetoothKit')

** ARCHIVE FAILED **
```