### PR TITLE
Support Xcode 15

### DIFF
--- a/Source/Unimplemented.swift
+++ b/Source/Unimplemented.swift
@@ -9,6 +9,6 @@ extension Observable {
     static func unimplemented(file: String = #file, function: String = #function, line: Int = #line)
         -> Observable<Element> {
         unimplementedFunction(file: file, function: function, line: line)
-        return Observable<Element>.empty()
+        return RxSwift.Observable<Element>.empty()
     }
 }


### PR DESCRIPTION
RxSwift's `Observable` conflicts with Apple's `Observable`, so make sure we pick the correct one.

Make sure you can build with Xcode 15.