### PR TITLE
Bump RxSwift to `6.8.0`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "RxSwift",
-        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
-          "version": "6.7.1"
-        }
+  "pins" : [
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "c7c7d2cf50a3211fe2843f76869c698e4e417930",
+        "version" : "6.8.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "RxBluetoothKit_Airthings", targets: ["RxBluetoothKit_Airthings"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMinor(from: "6.7.1"))
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMinor(from: "6.8.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
I'm updating mainly because `6.8.0` implements the missing bridges between RxSwift and Swift Concurrency.

https://github.com/ReactiveX/RxSwift/compare/6.7.1...6.8.0